### PR TITLE
Fix "container does not reference a native integer" errors

### DIFF
--- a/lib/Intl/CLDR/Types/CompoundUnitSet.pm6
+++ b/lib/Intl/CLDR/Types/CompoundUnitSet.pm6
@@ -9,13 +9,13 @@ use Intl::CLDR::Enums;
 
 method of (-->Str) {}
 
-has int  $!length-coefficient is built;
+has uint $!length-coefficient is built;
 has buf8 $!length-table       is built;
-has int  $!case-coefficient   is built;
+has uint $!case-coefficient   is built;
 has buf8 $!case-table         is built;
-has int  $!count-coefficient  is built;
+has uint $!count-coefficient  is built;
 has buf8 $!count-table        is built;
-has int  $!gender-coefficient is built;
+has uint $!gender-coefficient is built;
 has buf8 $!gender-table       is built;
 has Str  @!patterns           is built;
 
@@ -37,13 +37,13 @@ method !gender-table        { $!gender-table        }
 method new(\blob, uint64 $offset is rw --> ::?CLASS) {
     use Intl::CLDR::Util::StrDecode;
 
-    my int   $length-coefficient     = blob[$offset++];
+    my uint  $length-coefficient     = blob[$offset++];
     my blob8 $length-table           = blob.subbuf($offset, 3); $offset += 3;
-    my int   $count-coefficient      = blob[$offset++];
+    my uint  $count-coefficient      = blob[$offset++];
     my blob8 $count-table            = blob.subbuf($offset, 8); $offset += 8;
-    my int   $case-coefficient       = blob[$offset++];
+    my uint  $case-coefficient       = blob[$offset++];
     my blob8 $case-table             = blob.subbuf($offset, 14); $offset += 14;
-    my int   $gender-coefficient     = blob[$offset++];
+    my uint  $gender-coefficient     = blob[$offset++];
     my blob8 $gender-table           = blob.subbuf($offset, 7); $offset += 7;
     my Str   @patterns;
     @patterns[$_] := StrDecode::get(blob, $offset)

--- a/lib/Intl/CLDR/Types/CurrencyFormatSystem.pm6
+++ b/lib/Intl/CLDR/Types/CurrencyFormatSystem.pm6
@@ -6,11 +6,11 @@ use Intl::CLDR::Types::NumberFormatSet;
 
 has CLDR-NumberFormat     $.standard;
 has CLDR-NumberFormat     $.standard-accounting;
-has int                   $!length-coefficient;
+has uint                  $!length-coefficient;
 has buf8                  $!length-table;
-has int                   $!currency-coefficient;
+has uint                  $!currency-coefficient;
 has buf8                  $!currency-table;
-has int                   $!count-coefficient;
+has uint                  $!count-coefficient;
 has buf8                  $!count-table;
 has CLDR-NumberFormatSet  @!sets;
 

--- a/lib/Intl/CLDR/Types/DecimalFormatSystem.pm6
+++ b/lib/Intl/CLDR/Types/DecimalFormatSystem.pm6
@@ -5,9 +5,9 @@ use Intl::CLDR::Types::NumberFormat;
 use Intl::CLDR::Types::NumberFormatSet;
 
 has CLDR-NumberFormat    $.standard;
-has int                  $!length-coefficient;
+has uint                 $!length-coefficient;
 has buf8                 $!length-table;
-has int                  $!count-coefficient;
+has uint                 $!count-coefficient;
 has buf8                 $!count-table;
 has CLDR-NumberFormatSet @!sets;
 

--- a/lib/Intl/CLDR/Types/PercentFormatSystem.pm6
+++ b/lib/Intl/CLDR/Types/PercentFormatSystem.pm6
@@ -5,9 +5,9 @@ use Intl::CLDR::Types::NumberFormat;
 use Intl::CLDR::Types::NumberFormatSet;
 
 has CLDR-NumberFormat    $.standard;
-has int                  $!length-coefficient;
+has uint                 $!length-coefficient;
 has buf8                 $!length-table;
-has int                  $!count-coefficient;
+has uint                 $!count-coefficient;
 has buf8                 $!count-table;
 has CLDR-NumberFormatSet @!sets;
 

--- a/lib/Intl/CLDR/Types/ScientificFormatSystem.pm6
+++ b/lib/Intl/CLDR/Types/ScientificFormatSystem.pm6
@@ -5,9 +5,9 @@ use Intl::CLDR::Types::NumberFormat;
 use Intl::CLDR::Types::NumberFormatSet;
 
 has CLDR-NumberFormat    $.standard;
-has int                  $!length-coefficient;
+has uint                 $!length-coefficient;
 has buf8                 $!length-table;
-has int                  $!count-coefficient;
+has uint                 $!count-coefficient;
 has buf8                 $!count-table;
 has CLDR-NumberFormatSet @!sets;
 

--- a/lib/Intl/CLDR/Types/SimpleUnitSet.pm6
+++ b/lib/Intl/CLDR/Types/SimpleUnitSet.pm6
@@ -9,11 +9,11 @@ unit class CLDR::SimpleUnitSet;
 has Gender::Gender $.gender    is built;
 has str   @!display-names      is built;
 has str   @!per-unit-patterns  is built;
-has int   $!length-coefficient is built;
+has uint  $!length-coefficient is built;
 has buf8  $!length-table       is built;
-has int   $!case-coefficient   is built;
+has uint  $!case-coefficient   is built;
 has buf8  $!case-table         is built;
-has int   $!count-coefficient  is built;
+has uint  $!count-coefficient  is built;
 has buf8  $!count-table        is built;
 has Str   @!patterns           is built;
 

--- a/lib/Intl/CLDR/Types/Subdivision.pm6
+++ b/lib/Intl/CLDR/Types/Subdivision.pm6
@@ -21,7 +21,7 @@ method new (\blob, uint64 $offset is rw --> ::?CLASS) {
 
     my \self-new = self.bless: :$id;
 
-    my int $count = blob[$offset++];
+    my uint $count = blob[$offset++];
 
     # Hashes do not have a build phase
     self-new.Hash::BIND-KEY:

--- a/lib/Intl/CLDR/Types/Subdivisions.pm6
+++ b/lib/Intl/CLDR/Types/Subdivisions.pm6
@@ -14,7 +14,7 @@ method of (--> CLDR::Subdivision) {}
 
 method new(\blob, uint64 $offset is rw --> ::?CLASS) {
     use Intl::CLDR::Util::StrDecode;
-    my int $count = blob[$offset++];
+    my uint $count = blob[$offset++];
     my \self-new = self.bless;
     for ^$count {
         self-new.Hash::BIND-KEY:


### PR DESCRIPTION
The next Rakudo version will finally have proper support for unsigned
native integers, i.e. it will no longer silently treat uint as int at
the first opportunity. Since blobs are using unsigned slot types by
default, we have to read values into uint typed variables, not int. This
is more correct anyway, as these values can never be negative. The fix
is backwards compatible as older Rakudo treated uint and int mostly the
same.